### PR TITLE
Align connection string with Aspire database name

### DIFF
--- a/Source/ABMGS.ServerV2.Migrations/Migraions.cs
+++ b/Source/ABMGS.ServerV2.Migrations/Migraions.cs
@@ -24,7 +24,7 @@ public class SyncnetDbContextFactory : IDesignTimeDbContextFactory<SyncnetDbCont
     public SyncnetDbContext CreateDbContext(string[] args)
     {
         var options = new DbContextOptionsBuilder<SyncnetDbContext>()
-            .UseNpgsql(_applicationBuilder.Configuration.GetConnectionString("npgsql"), options => {
+            .UseNpgsql(_applicationBuilder.Configuration.GetConnectionString("SyncnetPlatform"), options => {
                 options.MigrationsAssembly("ABMGS.Serverv2.Package");
             })
             .Options;

--- a/Source/ABMGS.ServerV2.Silo/appsettings.Development.json
+++ b/Source/ABMGS.ServerV2.Silo/appsettings.Development.json
@@ -7,6 +7,6 @@
     },
     "ConnectionStrings": {
         "redis": "localhost:6379",
-        "npgsql": "Host=127.0.0.1;Username=postgres;Password=1234;Port=5432;Database=SyncnetPlatform"
+        "SyncnetPlatform": "Host=127.0.0.1;Username=postgres;Password=1234;Port=5432;Database=SyncnetPlatform"
     }
 }

--- a/Source/ABMGS.ServerV2/appsettings.Development.json
+++ b/Source/ABMGS.ServerV2/appsettings.Development.json
@@ -7,6 +7,6 @@
     },
     "ConnectionStrings": {
         "redis": "localhost:6379",
-        "npgsql": "Host=127.0.0.1;Username=postgres;Password=1234;Database=SyncnetPlatform"
+        "SyncnetPlatform": "Host=127.0.0.1;Username=postgres;Password=1234;Database=SyncnetPlatform"
     }
 }

--- a/Source/ABMGS.Serverv2.Package/Extensions/FrontendApplicationBuilderExtension.cs
+++ b/Source/ABMGS.Serverv2.Package/Extensions/FrontendApplicationBuilderExtension.cs
@@ -29,7 +29,7 @@ public static class FrontendApplicationBuilderExtension
         builder.Services.AddTransient<ISystemPacketHandler, SystemPacketHandler>();
 
         builder.Services.AddDbContextPool<SyncnetDbContext>(opt => {
-            opt.UseNpgsql(builder.Configuration.GetConnectionString("npgsql"));
+            opt.UseNpgsql(builder.Configuration.GetConnectionString("SyncnetPlatform"));
         });
         builder.Services.AddTransient<IPlayerModelRepositoy, rdbPlayerModelRepository>();
 

--- a/Source/ABMGS.Serverv2.Package/Extensions/SiloApplicationBuilderExtension.cs
+++ b/Source/ABMGS.Serverv2.Package/Extensions/SiloApplicationBuilderExtension.cs
@@ -40,7 +40,7 @@ public static class SiloApplicationBuilderExtension
     {
         builder.Services.AddDbContextPool<SyncnetDbContext>(opt =>
         {
-            opt.UseNpgsql(builder.Configuration.GetConnectionString("npgsql"), optionBuilder =>
+            opt.UseNpgsql(builder.Configuration.GetConnectionString("SyncnetPlatform"), optionBuilder =>
             {
                 optionBuilder.MigrationsAssembly(typeof(SyncnetDbContext).Assembly.FullName);
             });
@@ -87,7 +87,7 @@ public class SyncnetSiloOptionsBuilder
         UseBuiltinDbContext = false;
         builder.Services.AddDbContextPool<DbContextType>(opt =>
         {
-            opt.UseNpgsql(builder.Configuration.GetConnectionString("npgsql"), optionBuilder =>
+            opt.UseNpgsql(builder.Configuration.GetConnectionString("SyncnetPlatform"), optionBuilder =>
             {
                 optionBuilder.MigrationsAssembly(typeof(DbContextType).Assembly.FullName);
             });


### PR DESCRIPTION
## Summary
- align database connection string key with the Aspire Postgres database resource name
- update DbContext registrations and migration factory to consume the renamed connection string
- adjust development configuration to expose the updated connection string

## Testing
- not run (dotnet SDK unavailable in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932d83b2db8832a985ff8d05fb7e9f8)