### PR TITLE
Fix naming and clean up data access code

### DIFF
--- a/Source/ABMGS.ServerV2.Migrations/Migrations.cs
+++ b/Source/ABMGS.ServerV2.Migrations/Migrations.cs
@@ -1,5 +1,3 @@
-
-
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.EntityFrameworkCore;
@@ -9,16 +7,16 @@ using SyncnetPlatform.Databases;
 public class SyncnetDbContextFactory : IDesignTimeDbContextFactory<SyncnetDbContext>
 {
     protected HostApplicationBuilder _applicationBuilder;
-    public SyncnetDbContextFactory(): base()
+    public SyncnetDbContextFactory() : base()
     {
-        string? EnvironmentName = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        string? environmentName = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
 
         _applicationBuilder = Host.CreateApplicationBuilder();
 
         _applicationBuilder.Configuration
             .SetBasePath(Directory.GetCurrentDirectory())
             .AddJsonFile("appsettings.json", false, true)
-            .AddJsonFile($"appsettings.{EnvironmentName}.json", true, true)
+            .AddJsonFile($"appsettings.{environmentName}.json", true, true)
             .AddEnvironmentVariables();
     }
     public SyncnetDbContext CreateDbContext(string[] args)
@@ -32,8 +30,3 @@ public class SyncnetDbContextFactory : IDesignTimeDbContextFactory<SyncnetDbCont
         return new SyncnetDbContext(options);
     }
 }
-
-
-
-
-

--- a/Source/ABMGS.ServerV2.Silo/Models/PlayerModelExtend.cs
+++ b/Source/ABMGS.ServerV2.Silo/Models/PlayerModelExtend.cs
@@ -7,7 +7,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 public class SyncnetDbContextExtend : SyncnetDbContext
 {
 
-    public DbSet<PlayerDataModelExtend> playerExtend { get; set; }
+    public DbSet<PlayerDataModelExtend> PlayerExtend { get; set; }
     public SyncnetDbContextExtend(DbContextOptions<SyncnetDbContextExtend> options) : base(options)
     {
     }
@@ -16,8 +16,6 @@ public class SyncnetDbContextExtend : SyncnetDbContext
     {
         modelBuilder.Entity<PlayerDataModelExtend>().HasKey(p => p.Id);
         modelBuilder.Entity<PlayerDataModelExtend>().Property(p => p.Id).ValueGeneratedOnAdd();
-
-        // modelBuilder.Entity<PlayerDataModelExtend>().HasOne<PlayerDataModel>().WithMany().HasForeignKey(p => p.PlayerId).OnDelete(DeleteBehavior.Cascade);
         modelBuilder.Entity<PlayerDataModelExtend>()
             .HasOne<PlayerDataModel>()
             .WithMany()
@@ -35,9 +33,9 @@ public class PlayerDataBehavior : IPlayerDataBehavior
     public async Task OnCreateNewPlayer(PlayerDataContext ctx)
     {
         var db = ctx.Db as SyncnetDbContextExtend;
-        if( db != null )
+        if (db != null)
         {
-            await db.playerExtend.AddAsync(new PlayerDataModelExtend
+            await db.PlayerExtend.AddAsync(new PlayerDataModelExtend
             {
                 PlayerId = ctx.PlayerId,
                 Level = 1,

--- a/Source/ABMGS.Serverv2.Package/Actors/PlayerActor.cs
+++ b/Source/ABMGS.Serverv2.Package/Actors/PlayerActor.cs
@@ -1,14 +1,8 @@
 using Microsoft.Extensions.Logging;
-using SyncnetPlatform.Databases;
 using SyncnetPlatform.Interfaces.Actors;
-using SyncnetPlatform.Interfaces.Network.Handlers;
-using SyncnetPlatform.Network.Handlers;
 using SyncnetPlatform.Repositories;
-using System.Net.WebSockets;
-using System.Runtime.CompilerServices;
 
 namespace SyncnetPlatform.Actors;
-
 
 public interface IPlayerBehavior
 {
@@ -18,36 +12,24 @@ public interface IPlayerBehavior
 public class PlayerActor : Grain, IPlayerActor
 {
     private readonly ILogger<PlayerActor> _logger;
-    private readonly IPlayerModelRepositoy _repository;
+    private readonly IPlayerModelRepository _repository;
 
     public PlayerActor(
         ILogger<PlayerActor> logger,
-        IPlayerModelRepositoy repository)
+        IPlayerModelRepository repository)
     {
         _logger = logger;
         _repository = repository;
     }
 
-    public async override Task OnActivateAsync(CancellationToken cancellationToken)
+    public override Task OnActivateAsync(CancellationToken cancellationToken)
     {
-        //Guid PlayerId = this.GetPrimaryKey();
-        //PlayerDataModel? playerDataModel = await _repository.Get(PlayerId);
-        //if (playerDataModel == null) {
-        //    await _repository.Create(new PlayerDataModel
-        //    {
-        //        PlayerId = PlayerId,
-        //        PlayerName = String.Empty,
-        //        Introduction = String.Empty
-        //    });
-        //}
-        
+        return Task.CompletedTask;
     }
-    
-    
 
-    public async Task Echo(int seq)
+    public Task Echo(int seq)
     {
-        
+        return Task.CompletedTask;
     }
 
 }

--- a/Source/ABMGS.Serverv2.Package/Extensions/FrontendApplicationBuilderExtension.cs
+++ b/Source/ABMGS.Serverv2.Package/Extensions/FrontendApplicationBuilderExtension.cs
@@ -31,7 +31,7 @@ public static class FrontendApplicationBuilderExtension
         builder.Services.AddDbContextPool<SyncnetDbContext>(opt => {
             opt.UseNpgsql(builder.Configuration.GetConnectionString("SyncnetPlatform"));
         });
-        builder.Services.AddTransient<IPlayerModelRepositoy, rdbPlayerModelRepository>();
+        builder.Services.AddTransient<IPlayerModelRepository, RdbPlayerModelRepository>();
 
 
         builder.UseOrleansClient(configure =>

--- a/Source/ABMGS.Serverv2.Package/Extensions/SiloApplicationBuilderExtension.cs
+++ b/Source/ABMGS.Serverv2.Package/Extensions/SiloApplicationBuilderExtension.cs
@@ -20,7 +20,7 @@ public static class SiloApplicationBuilderExtension
         builder.Services.AddTransient<IPacketRouter, FlatBufferPacketRouter>();
         builder.Services.AddSingleton<IPacketContextFactory, PacketContextFactory>();
         builder.Services.AddTransient<ISystemPacketHandler, SystemPacketHandler>();
-        builder.Services.AddTransient<IPlayerModelRepositoy, rdbPlayerModelRepository>();
+        builder.Services.AddTransient<IPlayerModelRepository, RdbPlayerModelRepository>();
 
         builder.UseOrleans(builder =>
         {
@@ -45,13 +45,6 @@ public static class SiloApplicationBuilderExtension
                 optionBuilder.MigrationsAssembly(typeof(SyncnetDbContext).Assembly.FullName);
             });
         });
-        //builder.Services.AddDbContextFactory<SyncnetDbContext>(opt =>
-        //{
-        //    opt.UseNpgsql(builder.Configuration.GetConnectionString("npgsql"), optionBuilder =>
-        //    {
-        //        optionBuilder.MigrationsAssembly(typeof(SyncnetDbContext).Assembly.FullName);
-        //    });
-        //});
     }
     public static void AddSyncnetPlatformSilo(this HostApplicationBuilder builder)
     {
@@ -92,13 +85,6 @@ public class SyncnetSiloOptionsBuilder
                 optionBuilder.MigrationsAssembly(typeof(DbContextType).Assembly.FullName);
             });
         });
-        //builder.Services.AddDbContextFactory<DbContextType>(opt =>
-        //{
-        //    opt.UseNpgsql(builder.Configuration.GetConnectionString("npgsql"), optionBuilder =>
-        //    {
-        //        optionBuilder.MigrationsAssembly(typeof(DbContextType).Assembly.FullName);
-        //    });
-        //});
         builder.Services.AddScoped<SyncnetDbContext>(sp => sp.GetRequiredService<DbContextType>());
     }
 }

--- a/Source/ABMGS.Serverv2.Package/Repositories/RdbPlayerModelRepository.cs
+++ b/Source/ABMGS.Serverv2.Package/Repositories/RdbPlayerModelRepository.cs
@@ -2,19 +2,18 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using SyncnetPlatform.Databases;
 using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 
 namespace SyncnetPlatform.Repositories;
 
-public class rdbPlayerModelRepository : IPlayerModelRepositoy
+public class RdbPlayerModelRepository : IPlayerModelRepository
 {
-    private readonly ILogger<rdbPlayerModelRepository> _logger;
+    private readonly ILogger<RdbPlayerModelRepository> _logger;
     private readonly SyncnetDbContext _syncnetDbContext;
 
-    public rdbPlayerModelRepository(
+    public RdbPlayerModelRepository(
         SyncnetDbContext syncnetDbContext,
-        ILogger<rdbPlayerModelRepository> logger)
+        ILogger<RdbPlayerModelRepository> logger)
     {
         _syncnetDbContext = syncnetDbContext;
         _logger = logger;
@@ -39,7 +38,7 @@ public class rdbPlayerModelRepository : IPlayerModelRepositoy
     }
 }
 
-public interface IPlayerModelRepositoy
+public interface IPlayerModelRepository
 {
     Task Create(PlayerDataModel newPlayerDataModel);
     Task<PlayerDataModel?> Get(Guid playerId);


### PR DESCRIPTION
## Summary
- rename player repository types to follow C# naming conventions and update dependency registration
- clean up player context extension and actor stubs by removing dead code and normalizing property names
- fix migration factory variable naming and file typo

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936f2efacbc832aa49787ddc4a37204)